### PR TITLE
Change testing to use in memory database

### DIFF
--- a/ctf/__init__.py
+++ b/ctf/__init__.py
@@ -2,25 +2,20 @@ import json
 import os
 import flask
 import redis
-import tempfile
 from werkzeug import exceptions
 from . import api, frontend, ext
 from .models import db
 
 
-def create_app(test=False):
+def create_app():
     app = flask.Flask(__name__)
     config_file = "./ctf.json"
 
     if 'CTF_CONFIG' in os.environ:
-        config_file = os.enviorn['CTF_CONFIG']
+        config_file = os.environ['CTF_CONFIG']
 
     with open(config_file, 'r') as config:
         app.config.update(json.load(config))
-
-    if test:
-        app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///%s' % \
-         tempfile.mktemp()
 
     app.redis = redis.StrictRedis()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,11 +3,13 @@ from ctf import create_app
 import fakeredis
 import json
 import pytest
+import os
 
 
 @pytest.fixture
 def app():
-    app = create_app(test=True)
+    os.environ["CTF_CONFIG"] = "tests/test_config.json"
+    app = create_app()
     app.redis = fakeredis.FakeRedis()
     app.secret_key = 'my secret key'
     app.debug = True

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,11 +3,13 @@ from ctf.ext import db
 from ctf.frontend import is_safe_url
 import fakeredis
 import pytest
+import os
 
 
 @pytest.fixture
 def app():
-    app = create_app(test=True)
+    os.environ["CTF_CONFIG"] = "tests/test_config.json"
+    app = create_app()
     app.redis = fakeredis.FakeRedis()
     app.secret_key = 'my secret key'
     app.debug = True

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -1,0 +1,10 @@
+{
+    "SQLALCHEMY_DATABASE_URI":"sqlite://",
+    "SQLALCHEMY_TRACK_MODIFICATIONS": false,
+    "SECRET_KEY":"not secure brah",
+    "CTF": {
+        "name":"Wrath CTF",
+        "start_time":"2016-08-01T12:00:00.000Z",
+        "end_time":"2016-10-01T12:00:00.000Z"
+    }
+}

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -2,11 +2,13 @@
 from ctf import create_app, ext, frontend
 import fakeredis
 import pytest
+import os
 
 
 @pytest.fixture
 def app(monkeypatch):
-    app = create_app(test=True)
+    os.environ["CTF_CONFIG"] = "tests/test_config.json"
+    app = create_app()
     app.redis = fakeredis.FakeRedis()
     app.secret_key = 'my secret key'
     app.debug = True


### PR DESCRIPTION
Right now we just create a new database each time, but if we use
in memory, we can get the same results without needing a parameter
in create_app